### PR TITLE
feat(vaults): add vaults/all endpoint

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -78,6 +78,23 @@ functions:
               type: 'boolean'
               required: false
 
+  vaults-all:
+    handler: services/vaults/all/handler.handler
+    role: arn:aws:iam::698083237070:role/service-role/fetchTokenIds-role-o9i24lq2
+    timeout: 30
+    events:
+      - http:
+          path: /vaults/all
+          method: get
+          cors: true
+          documentation:
+            summary: Gets all vaults (all versions) from the vault registry
+            tags:
+              - Vaults
+            description: >
+              V1 vaults are pulled from the vault registry (https://etherscan.io/address/0x3ee41c098f9666ed2ea246f4d2558010e59d63a0).
+              V2 vaults are pulled from thegraph (https://api.thegraph.com/subgraphs/name/salazarguille/yearn-vaults-v2-subgraph-rinkeby).
+
   vaults-snapshots:
     handler: services/vaults/snapshots/handler.handler
     role: arn:aws:iam::698083237070:role/service-role/fetchTokenIds-role-o9i24lq2

--- a/services/vaults/all/handler.js
+++ b/services/vaults/all/handler.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const _ = require('lodash');
+
+const handler = require('../../../lib/handler');
+
+const { getVaults } = require('../handler');
+const { getVaultsV2 } = require('../v2/handler');
+
+const V2_KEYMAP = {
+  vault: 'address',
+  vaultName: 'name',
+  vaultSymbol: 'symbol',
+  vaultDecimals: 'decimals',
+};
+
+module.exports.handler = handler(async () => {
+  const v1 = _(await getVaults())
+    .map((val) => _.pick(val, ['address', 'name', 'symbol', 'decimals']))
+    .map((val) => _.assign({}, val, { type: 'v1' }))
+    .value();
+
+  const v2 = _(await getVaultsV2())
+    .map((val) => _.mapKeys(val, (__, k) => V2_KEYMAP[k]))
+    .map((val) => _.pick(val, ['address', 'name', 'symbol', 'decimals']))
+    .map((val) => _.assign({}, val, { type: 'v2' }))
+    .value();
+  return _.merge(v1, v2);
+});

--- a/services/vaults/v2/handler.js
+++ b/services/vaults/v2/handler.js
@@ -7,7 +7,7 @@ const fetch = require('node-fetch');
 const subgraphUrl =
   'https://api.thegraph.com/subgraphs/name/salazarguille/yearn-vaults-v2-subgraph-rinkeby';
 
-const getGraphData = async () => {
+const getVaultsV2 = async () => {
   const query = `
   {
   vaults {
@@ -47,11 +47,13 @@ const getGraphData = async () => {
     body: JSON.stringify({ query }),
   });
   const responseJson = await response.json();
-  const graphData = responseJson.data;
-  return graphData;
+  const data = responseJson.data;
+  return data.vaults;
 };
 
+module.exports.getVaultsV2 = getVaultsV2;
+
 module.exports.handler = handler(async () => {
-  const graphData = await getGraphData();
-  return graphData;
+  const vaults = await getVaultsV2();
+  return vaults;
 });


### PR DESCRIPTION
Discussed in discord PMs.

Short summary:
- added the `vaults/all` endpoint that returns V1 & V2 vaults, following the format:

```json
[{
   "address": "0x123...",
   "name": "vault name",
   "symbol": "vault symbol",
   "decimals": "vault decimals",
   "type": "v1"
}]
```