### PR TITLE
feat(vaults): add assets and token fields to endpoint

### DIFF
--- a/abi/erc20.json
+++ b/abi/erc20.json
@@ -1,0 +1,222 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+]

--- a/services/vaults/all/handler.js
+++ b/services/vaults/all/handler.js
@@ -1,57 +1,58 @@
 'use strict';
 
-const _ = require('lodash');
+// const _ = require('lodash');
 
 const Web3BatchCall = require('web3-batch-call');
 const delay = require('delay');
 
 const handler = require('../../../lib/handler');
+const erc20Abi = require('../../../abi/erc20.json');
 
 const vaultInterface = require('../lib/vaults');
 
-module.exports.handler = handler(async () => {
+// FetchTokenDetails with a batch call to all the available addresses for each
+// version. Extracting name, symbol, decimails and the token address.
+const fetchVaults = async (client) => {
   const v1Addresses = await vaultInterface.v1.fetchAddresses();
   const v2Addresses = await vaultInterface.v2.fetchAddresses();
 
-  const provider = process.env.WEB3_ENDPOINT;
-  const etherscanApiKey = process.env.ETHERSCAN_API_KEY;
-
-  const batchCall = new Web3BatchCall({
-    provider,
-    etherscan: {
-      apiKey: etherscanApiKey,
-      delay: 300,
-    },
-  });
-
+  const readMethods = [
+    { name: 'name' },
+    { name: 'symbol' },
+    { name: 'decimals' },
+    { name: 'token' },
+  ];
   const contracts = [
     {
       namespace: 'v1',
       addresses: v1Addresses,
       abi: vaultInterface.v1.abi(),
-      readMethods: [{ name: 'name' }, { name: 'symbol' }, { name: 'decimals' }],
+      readMethods,
     },
     {
       namespace: 'v2',
       addresses: v2Addresses,
       abi: vaultInterface.v2.abi(),
-      readMethods: [{ name: 'name' }, { name: 'symbol' }, { name: 'decimals' }],
+      readMethods,
     },
   ];
 
   // Vaults data
-  const res = await batchCall.execute(contracts);
-  let vaults = _(res)
-    .map(({ address, namespace: type, name, symbol, decimals }) => ({
+  const res = await client.execute(contracts);
+  const vaults = res.map(
+    ({ address, namespace: type, name, symbol, decimals, token }) => ({
       address,
       type,
       name: name[0].value,
       symbol: symbol[0].value,
       decimals: decimals[0].value,
-    }))
-    .value();
+      token: {
+        address: token[0].value,
+      },
+    }),
+  );
 
-  // Inception block
+  // Inject inception block from etherscan
   for (const vault of vaults) {
     const { address } = vault;
     const inceptionBlock = await vaultInterface.getInceptionBlock(address);
@@ -59,22 +60,80 @@ module.exports.handler = handler(async () => {
     vault.inceptionBlock = inceptionBlock;
   }
 
+  return vaults;
+};
+
+// FetchTokenDetails with a batch call to the ERC20 token addresses inside
+// each vault. Extracting name, symbol and decimals.
+const fetchTokenDetails = async (client, vaults) => {
+  const readMethods = [
+    { name: 'name' },
+    { name: 'symbol' },
+    { name: 'decimals' },
+  ];
+  const contracts = [
+    {
+      addresses: vaults.map(({ token }) => token.address),
+      abi: erc20Abi,
+      readMethods,
+    },
+  ];
+
+  const res = await client.execute(contracts);
+  return Object.fromEntries(
+    res.map(({ address, name, symbol, decimals }) => [
+      address,
+      {
+        address,
+        name: name[0].value,
+        symbol: symbol[0].value,
+        decimals: decimals[0].value,
+      },
+    ]),
+  );
+};
+
+module.exports.handler = handler(async () => {
+  const provider = process.env.WEB3_ENDPOINT;
+  const etherscanApiKey = process.env.ETHERSCAN_API_KEY;
+
+  const batchClient = new Web3BatchCall({
+    provider,
+    etherscan: {
+      apiKey: etherscanApiKey,
+      delay: 300,
+    },
+  });
+
+  const vaults = await fetchVaults(batchClient);
+
   // ROI
   const blockStats = await vaultInterface.roi.fetchBlockStats();
-  vaults = await Promise.all(
+  await Promise.all(
     vaults.map(async (vault) => {
-      let apy = {};
       try {
-        apy = await vaultInterface.roi.getVaultApy(vault, blockStats);
+        vault.apy = await vaultInterface.roi.getVaultApy(vault, blockStats);
       } catch {
-        apy = {};
+        vault.apy = {};
       }
-      return {
-        ...vault,
-        apy,
-      };
     }),
   );
+
+  // Token details & Assets
+  const tokenDetails = await fetchTokenDetails(batchClient, vaults);
+
+  const assets = await vaultInterface.assets.fetchAssets();
+  const aliases = await vaultInterface.assets.fetchAliases();
+
+  for (const vault of vaults) {
+    vault.token = tokenDetails[vault.token.address];
+
+    vault.token.displayName = aliases[vault.token.address] || vault.token.name;
+    vault.token.icon = assets[vault.token.address] || null;
+
+    vault.displayName = aliases[vault.address] || vault.name;
+    vault.icon = assets[vault.address] || null;
+  }
 
   return vaults;
 });

--- a/services/vaults/lib/vaults/assets.js
+++ b/services/vaults/lib/vaults/assets.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const fetch = require('node-fetch');
+
+const GHRAW = 'https://raw.githubusercontent.com';
+const GHAPI = 'https://api.github.com/repos';
+
+const ALIASES = `${GHRAW}/iearn-finance/yearn-assets/master/icons/aliases.json`;
+
+const YEARN_ASSETS = `${GHAPI}/iearn-finance/yearn-assets/contents/icons/tokens`;
+const yearnAssetUrl = (address) =>
+  `${GHRAW}/iearn-finance/yearn-assets/master/icons/tokens/${address}/logo-128.png`;
+
+const TRUST_ASSETS = `${GHRAW}/trustwallet/assets/master/blockchains/ethereum/tokenlist.json`;
+
+module.exports.fetchAliases = async () => {
+  const aliases = await fetch(ALIASES).then((res) => res.json());
+  return Object.fromEntries(
+    aliases.map((alias) => [alias.address, alias.name]),
+  );
+};
+
+const fetchYearnAssets = async () => {
+  const assets = await fetch(YEARN_ASSETS).then((res) => res.json());
+  return Object.fromEntries(
+    assets.map(({ name: address }) => [address, yearnAssetUrl(address)]),
+  );
+};
+
+const fetchTrustAssets = async () => {
+  const { tokens } = await fetch(TRUST_ASSETS).then((res) => res.json());
+  return Object.fromEntries(
+    tokens.map(({ address, logoURI }) => [address, logoURI]),
+  );
+};
+
+module.exports.fetchAssets = async () => {
+  const yearnAssets = await fetchYearnAssets();
+  const trustAssets = await fetchTrustAssets();
+  return { ...trustAssets, ...yearnAssets };
+};

--- a/services/vaults/lib/vaults/index.js
+++ b/services/vaults/lib/vaults/index.js
@@ -5,6 +5,7 @@ const fetch = require('node-fetch');
 module.exports.v1 = require('./v1');
 module.exports.v2 = require('./v2');
 module.exports.roi = require('./roi');
+module.exports.assets = require('./assets');
 
 const getInceptionBlock = async (vaultAddress) => {
   const params = new URLSearchParams();


### PR DESCRIPTION
Discussed in discord PMs.

Short summary:
- fetch assets from https://github.com/iearn-finance/yearn-assets and fallback to https://github.com/trustwallet/assets
- fetch token info from vault's `token.address`
- add a `displayName` for vaults and tokens
- `/vaults/all` now follows the format:
```json
[
    {
        "address": "0x29E240CFD7946BA20895a7a02eDb25C210f9f324",
        "type": "v1",
        "name": "yearn Aave Interest bearing LINK",
        "symbol": "yaLINK",
        "decimals": "18",
        "token": {
            "address": "0xA64BD6C70Cb9051F6A9ba1F163Fdc07E0DfB5F84",
            "name": "Aave Interest bearing LINK",
            "symbol": "aLINK",
            "decimals": "18",
            "displayName": "aLINK",
            "icon": "https://raw.githubusercontent.com/iearn-finance/yearn-assets/master/icons/tokens/0xA64BD6C70Cb9051F6A9ba1F163Fdc07E0DfB5F84/logo-128.png"
        },
        "inceptionBlock": "10599617",
        "apy": {
            "inceptionSample": 11.680565331008788,
            "oneMonthSample": 0.5690614438140246
        },
        "displayName": "aLINK yVault",
        "icon": "https://raw.githubusercontent.com/iearn-finance/yearn-assets/master/icons/tokens/0x29E240CFD7946BA20895a7a02eDb25C210f9f324/logo-128.png"
    },
    {"..."}
]
```