### PR TITLE
fix: extrapolate vault annual ROI correctly

### DIFF
--- a/services/vaults/apy/save/handler.js
+++ b/services/vaults/apy/save/handler.js
@@ -61,10 +61,10 @@ const getApy = async (previousValue, currentValue, previousBlockNbr) => {
   if (!previousValue) {
     return 0;
   }
-  const pricePerFullShareDelta = (currentValue - previousValue) / 1e18;
   const blockDelta = currentBlockNbr - previousBlockNbr;
-  const dailyRoi = (pricePerFullShareDelta / blockDelta) * 100 * nbrBlocksInDay;
-  const yearlyRoi = dailyRoi * 365;
+  const returnSincePrevBlock = (currentValue - previousValue) / previousValue;
+  const days = blockDelta / nbrBlocksInDay;
+  const yearlyRoi = 100 * ((1 + returnSincePrevBlock) ** (365 / days) - 1);
   return yearlyRoi;
 };
 


### PR DESCRIPTION
The flaw in the original calculation is explained in detail in a [blog post](https://www.southseacompany.xyz/posts/returns/).