### PR TITLE
Use raw.githack for serving response information for asset images

### DIFF
--- a/services/vaults/save/handler.js
+++ b/services/vaults/save/handler.js
@@ -33,7 +33,6 @@ const fetchAliasMetadata = async () => {
   return resp;
 };
 
-
 const fetchContractName = async (address) => {
   const metadata = await fetchContractMetadata(address);
   const contractName = metadata.ContractName;
@@ -109,7 +108,6 @@ module.exports.handler = handler(async () => {
 
     const vaultAlias = tokenSymbolAlias || tokenSymbol;
 
-    
     // githack provides proper Conttent-Type headers and caching via cloudflare
     // To purge cache go to: https://raw.githack.com/#purge
     const tokenIcon = `https://rawcdn.githack.com/iearn-finance/yearn-assets/master/icons/tokens/${tokenAddress}/logo-128.png`;

--- a/services/vaults/save/handler.js
+++ b/services/vaults/save/handler.js
@@ -33,6 +33,7 @@ const fetchAliasMetadata = async () => {
   return resp;
 };
 
+
 const fetchContractName = async (address) => {
   const metadata = await fetchContractMetadata(address);
   const contractName = metadata.ContractName;
@@ -108,8 +109,11 @@ module.exports.handler = handler(async () => {
 
     const vaultAlias = tokenSymbolAlias || tokenSymbol;
 
-    const tokenIcon = `https://raw.githubusercontent.com/iearn-finance/yearn-assets/master/icons/tokens/${tokenAddress}/logo-128.png`;
-    const vaultIcon = `https://raw.githubusercontent.com/iearn-finance/yearn-assets/master/icons/tokens/${vaultAddress}/logo-128.png`;
+    
+    // githack provides proper Conttent-Type headers and caching via cloudflare
+    // To purge cache go to: https://raw.githack.com/#purge
+    const tokenIcon = `https://rawcdn.githack.com/iearn-finance/yearn-assets/master/icons/tokens/${tokenAddress}/logo-128.png`;
+    const vaultIcon = `https://rawcdn.githack.com/iearn-finance/yearn-assets/master/icons/tokens/${vaultAddress}/logo-128.png`;
     const vault = {
       address: vaultAddress,
       name: vaultName,


### PR DESCRIPTION
This changes the URL addressing to use raw.githack instead of serving them via github.

**raw.githack.com** acts as a caching proxy, forwarding requests to the corresponding service, caching the responses either for a short time (in the case of development URLs) or permanently (in the case of CDN URLs), and relaying them to your browser with the correct `Content-Type` headers.